### PR TITLE
feat!: CID index sorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const writer = IndexSortedWriter.createWriter({ writer: writable.getWriter() })
 readable.pipeTo(Readable.toWeb(fs.createWriteStream('my.car.idx')))
 
 for await (const { cid, offset } of indexer) {
-  await writer.add(cid, offset)
+  await writer.add({ digest: cid.multihash.digest, offset })
 }
 await writer.close()
 ```
@@ -75,13 +75,13 @@ readable.pipeTo(new WritableStream()) // destination
 
 writer.add(carCID0, async ({ writer }) => {
   const index0 = MultihashIndexSortedWriter.createWriter({ writer })
-  index0.add(cid, offset)
+  index0.add({ multihash: cid.multihash, offset })
   await index0.close()
 })
 
 writer.add(carCID1, async ({ writer }) => {
   const index1 = MultihashIndexSortedWriter.createWriter({ writer })
-  index1.add(cid, offset)
+  index1.add({ multihash: cid.multihash, offset })
   await index1.close()
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "cardex": "src/bin.js"
       },
       "devDependencies": {
+        "@multiformats/blake2": "^2.0.2",
         "@types/node": "^20.2.5",
         "@types/varint": "^6.0.0",
         "ava": "^6.0.1",
@@ -148,6 +149,16 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@multiformats/blake2": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-2.0.2.tgz",
+      "integrity": "sha512-AOWu6Tyuk5UoT5m4faB6ntVnPB8EmuD6rn18s4cCgHNEGgsamT8GdvjP9DYjzFHQVaP/0L3CaKqWQqJlXx9ecw==",
+      "dev": true,
+      "dependencies": {
+        "blakejs": "^1.2.1",
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -551,6 +562,12 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "dev": true
     },
     "node_modules/blueimp-md5": {
       "version": "2.19.0",
@@ -4530,6 +4547,16 @@
         "tar": "^6.1.11"
       }
     },
+    "@multiformats/blake2": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-2.0.2.tgz",
+      "integrity": "sha512-AOWu6Tyuk5UoT5m4faB6ntVnPB8EmuD6rn18s4cCgHNEGgsamT8GdvjP9DYjzFHQVaP/0L3CaKqWQqJlXx9ecw==",
+      "dev": true,
+      "requires": {
+        "blakejs": "^1.2.1",
+        "multiformats": "^13.0.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4826,6 +4853,12 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "dev": true
     },
     "blueimp-md5": {
       "version": "2.19.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "varint": "^6.0.0"
   },
   "devDependencies": {
+    "@multiformats/blake2": "^2.0.2",
     "@types/node": "^20.2.5",
     "@types/varint": "^6.0.0",
     "ava": "^6.0.1",
@@ -62,6 +63,14 @@
     "./api": {
       "import": "./src/api.js",
       "types": "./types/api.d.ts"
+    },
+    "./cid-index-sorted": {
+      "import": "./src/cid-index-sorted/index.js",
+      "types": "./types/cid-index-sorted/index.d.ts"
+    },
+    "./cid-index-sorted/api": {
+      "import": "./src/cid-index-sorted/api.js",
+      "types": "./types/cid-index-sorted/api.d.ts"
     },
     "./index-sorted": {
       "import": "./src/index-sorted/index.js",
@@ -119,6 +128,12 @@
       ],
       "*": [
         "types/*"
+      ],
+      "cid-index-sorted": [
+        "types/cid-index-sorted/index.d.ts"
+      ],
+      "cid-index-sorted/api": [
+        "types/index-sorted/api.d.ts"
       ],
       "index-sorted": [
         "types/index-sorted/index.d.ts"

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,18 +1,14 @@
-import { Link, UnknownLink } from 'multiformats/link'
+import { Link } from 'multiformats/link'
 import { Writer } from './writer/api.js'
 import { Reader, ReadResult } from './reader/api.js'
 
+export type Unit = {}
 export type CARLink = Link<Uint8Array, 0x0202>
 
 export type MultihashCodec = number
 export type DigestLength = number
 
 export type Await<T> = T | PromiseLike<T>
-
-export interface IndexItem {
-  digest: Uint8Array
-  offset: number
-}
 
 export interface ReaderState {
   bytesReader: BytesReaderState
@@ -30,14 +26,14 @@ export interface CloseOptions {
   closeWriter?: boolean
 }
 
-export interface IndexWriter<S> {
+export interface IndexWriter<S, V extends Unit> {
   writer: Writer<Uint8Array>
   state: S
-  add (cid: UnknownLink, offset: number): Await<IndexWriter<S>>
+  add (item: V): Await<IndexWriter<S, V>>
   close (options?: CloseOptions): Await<void>
 }
 
-export interface IndexReader<S extends ReaderState = ReaderState, V extends IndexItem = IndexItem> {
+export interface IndexReader<S extends ReaderState, V extends Unit> {
   reader: Reader<Uint8Array>
   state: S
   read (): Await<ReadResult<V>>

--- a/src/bin.js
+++ b/src/bin.js
@@ -53,7 +53,12 @@ prog
           const indexer = await CarIndexer.fromIterable(carStream)
           const indexWriter = Writer.createWriter({ writer })
           for await (const { cid, offset } of indexer) {
-            await indexWriter.add(cid, offset)
+            await indexWriter.add(
+              // @ts-expect-error
+              opts.format === 'IndexSorted'
+                ? { digest: cid.multihash.digest, offset }
+                : { multihash: cid.multihash, offset }
+            )
           }
           await indexWriter.close()
         })
@@ -65,7 +70,12 @@ prog
       const carStream = fs.createReadStream(srcs[0])
       const indexer = await CarIndexer.fromIterable(carStream)
       for await (const { cid, offset } of indexer) {
-        await writer.add(cid, offset)
+        await writer.add(
+          // @ts-expect-error
+          opts.format === 'IndexSorted'
+            ? { digest: cid.multihash.digest, offset }
+            : { multihash: cid.multihash, offset }
+        )
       }
       await writer.close()
     }

--- a/src/cid-index-sorted/README.md
+++ b/src/cid-index-sorted/README.md
@@ -1,0 +1,22 @@
+# Format
+
+```
+varint codec
+  uint8 number of CID versions
+     (for each)
+     uint8 CID version
+     uint32 number of IPLD codecs
+         (for each)
+         uint64 IPLD codec
+         uint32 number of multihash codecs
+             (for each)
+             uint64 multihash codec
+             uint32 number of "width" groups
+                 (for each)
+                 uint32 group "width"
+                 uint64 group length
+                     (for each)
+                     digest
+                     uint64 offset
+                     uint64 length
+```

--- a/src/cid-index-sorted/api.js
+++ b/src/cid-index-sorted/api.js
@@ -1,0 +1,1 @@
+// this is dummy module overlayed by api.ts

--- a/src/cid-index-sorted/api.ts
+++ b/src/cid-index-sorted/api.ts
@@ -1,0 +1,37 @@
+import { UnknownLink, Version } from 'multiformats/link'
+import { ReaderState, MultihashCodec, DigestLength } from '../api.js'
+
+export interface CIDIndexSortedReaderState extends ReaderState {
+  started: boolean
+  versionsCount: number
+  versionsIndex: number
+  version: number
+  codesCount: number
+  codesIndex: number
+  code: number
+  mhCodesCount: number
+  mhCodesIndex: number
+  mhCode: number
+  bucketsCount: number
+  bucketIndex: number
+  width: number
+  itemsCount: number
+  itemIndex: number
+  done: boolean
+}
+
+export interface CIDIndexItem {
+  /** CID for the block. */
+  cid: UnknownLink
+  /** Offset to block _bytes_ from the beginning of the CAR. */
+  offset: number
+  /** Number of bytes of block data at `offset`. */
+  length: number
+}
+
+/** IPLD codec */
+export type Codec = number
+
+export interface CIDIndexSortedWriterState {
+  idxs: Map<Version, Map<Codec, Map<MultihashCodec, Map<DigestLength, CIDIndexItem[]>>>>
+}

--- a/src/cid-index-sorted/codec.js
+++ b/src/cid-index-sorted/codec.js
@@ -1,0 +1,4 @@
+/**
+ * Codec for the CIDIndexSorted format.
+ */
+export const CID_INDEX_SORTED_CODEC = 0x0403

--- a/src/cid-index-sorted/index.js
+++ b/src/cid-index-sorted/index.js
@@ -1,0 +1,2 @@
+export * as CIDIndexSortedReader from './reader.js'
+export * as CIDIndexSortedWriter from './writer.js'

--- a/src/cid-index-sorted/reader.js
+++ b/src/cid-index-sorted/reader.js
@@ -1,0 +1,150 @@
+import { create as createMultihash } from 'multiformats/hashes/digest'
+import { create as createLink, createLegacy as createLegacyLink } from 'multiformats/link'
+import { readUint32LE, readUint64LE, readUint8, readVarint } from '../decoder.js'
+import { BytesReader } from '../bytes-reader.js'
+import { CID_INDEX_SORTED_CODEC } from './codec.js'
+
+export const codec = CID_INDEX_SORTED_CODEC
+
+/**
+ * @param {{ state?: import('../api.js').ReaderState }} config
+ * @returns {import('./api.js').CIDIndexSortedReaderState}
+ */
+const init = config => {
+  return {
+    started: false,
+    versionsCount: 0,
+    versionsIndex: 0,
+    version: 0,
+    codesCount: 0,
+    codesIndex: 0,
+    code: 0,
+    mhCodesCount: 0,
+    mhCodesIndex: 0,
+    mhCode: 0,
+    bucketsCount: 0,
+    bucketIndex: 0,
+    width: 0,
+    itemsCount: 0,
+    itemIndex: 0,
+    done: false,
+    bytesReader: config.state?.bytesReader ?? BytesReader.init()
+  }
+}
+
+/**
+ * @param {{ reader: import('../reader/api.js').Reader<Uint8Array>, state?: import('../api.js').ReaderState }} config
+ * @returns {import('../api.js').IndexReader<import('./api.js').CIDIndexSortedReaderState, import('./api.js').CIDIndexItem>}
+ */
+export const createReader = ({ reader, state }) =>
+  new CIDIndexSortedReader({ reader, state: init({ state }) })
+
+/**
+ * @template {{ state: import('./api.js').CIDIndexSortedReaderState, reader: import('../reader/api.js').Reader<Uint8Array> }} View
+ * @param {View} view
+ * @returns {Promise<import('../reader/api.js').ReadResult<import('./api.js').CIDIndexItem>>}
+ */
+export const read = async ({ reader, state }) => {
+  if (state.done) return { done: true }
+
+  const bytesReader = new BytesReader({ reader, state: state.bytesReader })
+  if (!state.started) {
+    const codec = await readVarint(bytesReader)
+    if (codec !== CID_INDEX_SORTED_CODEC) {
+      throw new Error(`unexpected index codec: 0x${codec.toString(16)}`)
+    }
+    state.started = true
+    state.versionsCount = await readUint8(bytesReader)
+    state.versionsIndex = 0
+    state.version = await readUint8(bytesReader)
+
+    state.codesCount = await readUint32LE(bytesReader)
+    state.codesIndex = 0
+    state.code = await readUint64LE(bytesReader)
+
+    state.mhCodesCount = await readUint32LE(bytesReader)
+    state.mhCodesIndex = 0
+    state.mhCode = await readUint64LE(bytesReader)
+
+    state.bucketsCount = await readUint32LE(bytesReader)
+    state.bucketIndex = 0
+    state.width = await readUint32LE(bytesReader)
+    const length = await readUint64LE(bytesReader)
+    state.itemsCount = length / state.width
+    state.itemIndex = 0
+  }
+
+  // Read next item
+  const digest = await bytesReader.exactly(state.width - 16)
+  bytesReader.seek(state.width - 16)
+  const offset = await readUint64LE(bytesReader)
+  const length = await readUint64LE(bytesReader)
+  /** @type {import('./api.js').CIDIndexItem} */
+  const item = {
+    cid: state.version === 0
+      // @ts-expect-error multihash is not necessarily sha256
+      ? createLegacyLink(createMultihash(state.mhCode, digest))
+      : createLink(state.code, createMultihash(state.mhCode, digest)),
+    offset,
+    length
+  }
+
+  state.itemIndex++
+  if (state.itemIndex >= state.itemsCount) {
+    state.bucketIndex++
+    if (state.bucketIndex >= state.bucketsCount) {
+      state.mhCodesIndex++
+      if (state.mhCodesIndex >= state.mhCodesCount) {
+        state.codesIndex++
+        if (state.codesIndex >= state.codesCount) {
+          state.versionsIndex++
+          if (state.versionsIndex >= state.versionsCount) {
+            state.done = true
+            return { done: false, value: item }
+          }
+          state.version = await readUint8(bytesReader)
+          state.codesCount = await readUint32LE(bytesReader)
+          state.codesIndex = 0
+        }
+        state.code = await readUint64LE(bytesReader)
+        state.mhCodesCount = await readUint32LE(bytesReader)
+        state.mhCodesIndex = 0
+      }
+      state.mhCode = await readUint64LE(bytesReader)
+      state.bucketsCount = await readUint32LE(bytesReader)
+      state.bucketIndex = 0
+    }
+    state.width = await readUint32LE(bytesReader)
+    state.itemsCount = (await readUint64LE(bytesReader)) / state.width
+    state.itemIndex = 0
+  }
+
+  return { done: false, value: item }
+}
+
+/**
+ * @template {{ state: import('./api.js').CIDIndexSortedReaderState, reader: import('../reader/api.js').Reader<Uint8Array> }} View
+ * @param {View} view
+ * @param {any} [reason]
+ */
+export const cancel = ({ state, reader }, reason) => {
+  state.done = true
+  return reader.cancel(reason)
+}
+
+class CIDIndexSortedReader {
+  /** @param {{ reader: import('../reader/api.js').Reader<Uint8Array>, state: import('./api.js').CIDIndexSortedReaderState }} config */
+  constructor ({ reader, state }) {
+    this.reader = reader
+    this.state = state
+  }
+
+  read () {
+    return read(this)
+  }
+
+  /** @param {any} [reason] */
+  cancel (reason) {
+    return cancel(this, reason)
+  }
+}

--- a/src/cid-index-sorted/writer.js
+++ b/src/cid-index-sorted/writer.js
@@ -1,0 +1,133 @@
+import { compare } from 'uint8arrays/compare'
+import { writeUint8, writeUint32LE, writeUint64LE, writeVarint } from '../encoder.js'
+import { CID_INDEX_SORTED_CODEC } from './codec.js'
+
+export const codec = CID_INDEX_SORTED_CODEC
+
+/**
+ * @template {{ writer: import('../writer/api.js').Writer<Uint8Array> }} View
+ * @param {View} view
+ * @returns {import('../api.js').IndexWriter<import('./api.js').CIDIndexSortedWriterState, import('./api.js').CIDIndexItem>}
+ */
+export const createWriter = ({ writer }) => new CIDIndexSortedWriter({ writer })
+
+/**
+ * @template {{ state: import('./api.js').CIDIndexSortedWriterState }} View
+ * @param {View} view
+ * @param {import('./api.js').CIDIndexItem} item
+ */
+export const add = ({ state }, item) => {
+  const { version, code } = item.cid
+
+  let vidxs = state.idxs.get(version)
+  if (!vidxs) {
+    vidxs = new Map()
+    state.idxs.set(version, vidxs)
+  }
+
+  let cidxs = vidxs.get(code)
+  if (!cidxs) {
+    cidxs = new Map()
+    vidxs.set(code, cidxs)
+  }
+
+  let mcidx = cidxs.get(item.cid.multihash.code)
+  if (!mcidx) {
+    mcidx = new Map()
+    cidxs.set(item.cid.multihash.code, mcidx)
+  }
+
+  const idx = mcidx.get(item.cid.multihash.digest.length) ?? []
+  idx.push(item)
+  mcidx.set(item.cid.multihash.digest.length, idx)
+}
+
+// format:
+// varint codec
+// uint8 number of versions
+//     uint8 version
+//     uint32 number of codecs
+//         uint64 IPLD codec
+//         uint32 number of mh indexes
+
+/**
+ * @template {{ state: import('./api.js').CIDIndexSortedWriterState, writer: import('../writer/api.js').Writer<Uint8Array> }} View
+ * @param {View} view
+ * @param {import('../api.js').CloseOptions} options
+ */
+export const close = async ({ state, writer }, options) => {
+  await writeVarint(writer, codec)
+  await writeUint8(writer, state.idxs.size)
+
+  const vidxs = Array.from(state.idxs.entries()).sort((a, b) => b[0] - a[0])
+  for (const [v, vidx] of vidxs) {
+    await writeUint8(writer, v)
+    await writeUint32LE(writer, vidx.size)
+
+    const svidx = Array.from(vidx.entries()).sort((a, b) => a[0] - b[0])
+    for (const [c, cidx] of svidx) {
+      await writeUint64LE(writer, c)
+      await writeUint32LE(writer, cidx.size)
+
+      const mhidxs = Array.from(cidx.entries()).sort((a, b) => a[0] - b[0])
+      for (const [code, idxs] of mhidxs) {
+        /** @type {Array<{ width: number, index: Uint8Array }>} */
+        const compactedIdxs = []
+        for (const [width, idx] of idxs.entries()) {
+          const recordedWidth = width + 16
+          const compact = new Uint8Array(recordedWidth * idx.length)
+          const view = new DataView(compact.buffer)
+          idx
+            .sort((a, b) => compare(a.cid.multihash.digest, b.cid.multihash.digest))
+            .forEach((item, i) => {
+              const offset = i * recordedWidth
+              compact.set(item.cid.multihash.digest, offset)
+              view.setBigUint64(offset + item.cid.multihash.digest.length, BigInt(item.offset), true)
+              view.setBigUint64(offset + item.cid.multihash.digest.length + 8, BigInt(item.length), true)
+            })
+
+          compactedIdxs.push({ width: recordedWidth, index: compact })
+        }
+
+        compactedIdxs.sort((a, b) => a.width - b.width)
+
+        await writeUint64LE(writer, code)
+        await writeUint32LE(writer, compactedIdxs.length)
+        for (const { width, index } of compactedIdxs) {
+          await writeUint32LE(writer, width)
+          await writeUint64LE(writer, index.length)
+          await writer.write(index)
+        }
+      }
+    }
+  }
+
+  if (options?.closeWriter ?? true) {
+    await writer.close()
+  } else if (options?.releaseLock ?? true) {
+    writer.releaseLock()
+  }
+}
+
+class CIDIndexSortedWriter {
+  /**
+   * @param {object} config
+   * @param {import('../writer/api.js').Writer<Uint8Array>} config.writer
+   */
+  constructor ({ writer }) {
+    this.writer = writer
+    /** @type {import('./api.js').CIDIndexSortedWriterState} */
+    this.state = { idxs: new Map() }
+  }
+
+  /** @param {import('./api.js').CIDIndexItem} item */
+  add (item) {
+    add(this, item)
+    return this
+  }
+
+  /** @param {import('../api.js').CloseOptions} options */
+  close (options) {
+    return close(this, options)
+  }
+}

--- a/src/cid-index-sorted/writer.js
+++ b/src/cid-index-sorted/writer.js
@@ -51,7 +51,7 @@ export const close = async ({ state, writer }, options) => {
   await writeVarint(writer, codec)
   await writeUint8(writer, state.idxs.size)
 
-  const vidxs = Array.from(state.idxs.entries()).sort((a, b) => b[0] - a[0])
+  const vidxs = Array.from(state.idxs.entries()).sort((a, b) => a[0] - b[0])
   for (const [v, vidx] of vidxs) {
     await writeUint8(writer, v)
     await writeUint32LE(writer, vidx.size)

--- a/src/cid-index-sorted/writer.js
+++ b/src/cid-index-sorted/writer.js
@@ -42,14 +42,6 @@ export const add = ({ state }, item) => {
   mcidx.set(item.cid.multihash.digest.length, idx)
 }
 
-// format:
-// varint codec
-// uint8 number of versions
-//     uint8 version
-//     uint32 number of codecs
-//         uint64 IPLD codec
-//         uint32 number of mh indexes
-
 /**
  * @template {{ state: import('./api.js').CIDIndexSortedWriterState, writer: import('../writer/api.js').Writer<Uint8Array> }} View
  * @param {View} view

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -27,6 +27,18 @@ export async function peekVarint (reader) {
  * @param {import('./bytes-reader.js').BytesReader} reader
  * @returns {Promise<number>}
  */
+export async function readUint8 (reader) {
+  const arr = await reader.exactly(1)
+  const view = new DataView(arr.buffer, arr.byteOffset, arr.byteLength)
+  const n = view.getUint8(0)
+  reader.seek(1)
+  return n
+}
+
+/**
+ * @param {import('./bytes-reader.js').BytesReader} reader
+ * @returns {Promise<number>}
+ */
 export async function readUint32LE (reader) {
   const arr = await reader.exactly(4)
   const view = new DataView(arr.buffer, arr.byteOffset, arr.byteLength)

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -3,6 +3,24 @@ import varint from 'varint'
 /**
  * @param {number} num
  */
+export function encodeUint8 (num) {
+  const arr = new ArrayBuffer(1)
+  const view = new DataView(arr)
+  view.setUint8(0, num)
+  return new Uint8Array(arr)
+}
+
+/**
+ * @param {import('./writer/api.js').Writer<Uint8Array>} writer
+ * @param {number} num
+ */
+export function writeUint8 (writer, num) {
+  return writer.write(encodeUint8(num))
+}
+
+/**
+ * @param {number} num
+ */
 export function encodeUint32LE (num) {
   const arr = new ArrayBuffer(4)
   const view = new DataView(arr)

--- a/src/index-sorted/README.md
+++ b/src/index-sorted/README.md
@@ -1,0 +1,12 @@
+# Format
+
+```
+varint codec
+    uint32 number of "width" groups
+        (for each)
+        uint32 group "width"
+        uint64 group length
+            (for each)
+            digest
+            uint64 offset
+```

--- a/src/index-sorted/api.ts
+++ b/src/index-sorted/api.ts
@@ -1,4 +1,9 @@
-import { IndexItem, ReaderState, DigestLength } from '../api.js'
+import { ReaderState, DigestLength } from '../api.js'
+
+export interface IndexItem {
+  digest: Uint8Array
+  offset: number
+}
 
 export interface IndexSortedReaderState extends ReaderState {
   started: boolean

--- a/src/index-sorted/reader.js
+++ b/src/index-sorted/reader.js
@@ -23,7 +23,7 @@ const init = config => {
 
 /**
  * @param {{ reader: import('../reader/api.js').Reader<Uint8Array>, state?: import('../api.js').ReaderState }} config
- * @returns {import('../api.js').IndexReader<import('./api.js').IndexSortedReaderState, import('../api.js').IndexItem>}
+ * @returns {import('../api.js').IndexReader<import('./api.js').IndexSortedReaderState, import('./api.js').IndexItem>}
  */
 export const createReader = ({ reader, state }) =>
   new IndexSortedReader({ reader, state: init({ state }) })
@@ -31,7 +31,7 @@ export const createReader = ({ reader, state }) =>
 /**
  * @template {{ state: import('./api.js').IndexSortedReaderState, reader: import('../reader/api.js').Reader<Uint8Array> }} View
  * @param {View} view
- * @returns {Promise<import('../reader/api.js').ReadResult<import('../api.js').IndexItem>>}
+ * @returns {Promise<import('../reader/api.js').ReadResult<import('./api.js').IndexItem>>}
  */
 export const read = async ({ reader, state }) => {
   if (state.done) return { done: true }
@@ -55,7 +55,7 @@ export const read = async ({ reader, state }) => {
   const digest = await bytesReader.exactly(state.width - 8)
   bytesReader.seek(state.width - 8)
   const offset = await readUint64LE(bytesReader)
-  const item = /** @type {import('../api.js').IndexItem} */({ digest, offset })
+  const item = /** @type {import('./api.js').IndexItem} */({ digest, offset })
 
   state.itemIndex++
   if (state.itemIndex >= state.itemsCount) {

--- a/src/index-sorted/writer.js
+++ b/src/index-sorted/writer.js
@@ -7,7 +7,7 @@ export const codec = INDEX_SORTED_CODEC
 /**
  * @template {{ writer: import('../writer/api.js').Writer<Uint8Array> }} View
  * @param {View} view
- * @returns {import('../api.js').IndexWriter<import('./api.js').IndexSortedWriterState>}
+ * @returns {import('../api.js').IndexWriter<import('./api.js').IndexSortedWriterState, import('./api.js').IndexItem>}
  */
 export const createWriter = ({ writer }) =>
   new IndexSortedWriter({ writer })
@@ -15,13 +15,12 @@ export const createWriter = ({ writer }) =>
 /**
  * @template {{ state: import('./api.js').IndexSortedWriterState }} View
  * @param {View} view
- * @param {import('multiformats').UnknownLink} cid
- * @param {number} offset
+ * @param {import('./api.js').IndexItem} item
  */
-export const add = ({ state }, cid, offset) => {
-  const { digest } = cid.multihash
+export const add = ({ state }, item) => {
+  const { digest } = item
   const idx = state.idxs.get(digest.length) || []
-  idx.push({ digest, offset })
+  idx.push(item)
   state.idxs.set(digest.length, idx)
 }
 
@@ -76,13 +75,9 @@ class IndexSortedWriter {
     this.state = { idxs: new Map() }
   }
 
-  /**
-   * @param {import('multiformats').UnknownLink} cid
-   * @param {number} offset
-   * @returns {import('../api.js').IndexWriter<import('./api.js').IndexSortedWriterState>}
-   */
-  add (cid, offset) {
-    add(this, cid, offset)
+  /** @param {import('./api.js').IndexItem} item */
+  add (item) {
+    add(this, item)
     return this
   }
 

--- a/src/mh-index-sorted/README.md
+++ b/src/mh-index-sorted/README.md
@@ -1,0 +1,18 @@
+# Format
+
+```
+varint codec
+    uint32 number of IPLD codecs
+        (for each)
+        uint64 IPLD codec
+        uint32 number of multihash codecs
+            (for each)
+            uint64 multihash codec
+            uint32 number of "width" groups
+                (for each)
+                uint32 group "width"
+                uint64 group length
+                    (for each)
+                    digest
+                    uint64 offset
+```

--- a/src/mh-index-sorted/api.ts
+++ b/src/mh-index-sorted/api.ts
@@ -1,5 +1,5 @@
 import { MultihashDigest } from 'multiformats'
-import { IndexItem, ReaderState, MultihashCodec, DigestLength } from '../api.js'
+import { ReaderState, MultihashCodec, DigestLength } from '../api.js'
 
 export interface MultihashIndexSortedReaderState extends ReaderState {
   started: boolean
@@ -15,9 +15,10 @@ export interface MultihashIndexSortedReaderState extends ReaderState {
 }
 
 export interface MultihashIndexSortedWriterState {
-  mhIdxs: Map<MultihashCodec, Map<DigestLength, IndexItem[]>>
+  mhIdxs: Map<MultihashCodec, Map<DigestLength, MultihashIndexItem[]>>
 }
 
-export interface MultihashIndexItem extends IndexItem {
+export interface MultihashIndexItem {
   multihash: MultihashDigest
+  offset: number
 }

--- a/src/mh-index-sorted/reader.js
+++ b/src/mh-index-sorted/reader.js
@@ -62,7 +62,8 @@ export const read = async ({ reader, state }) => {
   const digest = await bytesReader.exactly(state.width - 8)
   bytesReader.seek(state.width - 8)
   const offset = await readUint64LE(bytesReader)
-  const item = /** @type {import('./api.js').MultihashIndexItem} */({ multihash: createMultihash(state.code, digest), digest, offset })
+  /** @type {import('./api.js').MultihashIndexItem} */
+  const item = { multihash: createMultihash(state.code, digest), offset }
 
   state.itemIndex++
   if (state.itemIndex >= state.itemsCount) {

--- a/src/multi-index/api.ts
+++ b/src/multi-index/api.ts
@@ -1,4 +1,4 @@
-import { Await, CARLink, ReaderState, IndexReader, IndexItem } from '../api.js'
+import { Await, CARLink, ReaderState, IndexReader, Unit } from '../api.js'
 import { Reader } from '../reader/api.js'
 import { Writer } from '../writer/api.js'
 
@@ -7,9 +7,9 @@ export interface MultiIndexReaderState extends ReaderState {
   carsCount: number
   carIndex: number
   car: CARLink | null
-  index: IndexReader | null
+  index: IndexReader<ReaderState, Unit> | null
   done: boolean
-  indexReaders: Map<number, IndexReaderFactory>
+  indexReaders: Map<number, IndexReaderFactory<ReaderState, Unit>>
 }
 
 export interface WriterReceiver {
@@ -20,11 +20,11 @@ export interface MultiIndexWriterState {
   builders: Array<{ cid: CARLink, builder: WriterReceiver }>
 }
 
-export interface MultiIndexItem extends IndexItem {
+export interface MultiIndexItem {
   origin: CARLink
 }
 
-export interface IndexReaderFactory<S extends ReaderState = ReaderState, V extends IndexItem = IndexItem> {
+export interface IndexReaderFactory<S extends ReaderState, V extends Unit> {
   codec: number
   createReader (config: { reader: Reader<Uint8Array>, state?: S }): IndexReader<S, V>
 }

--- a/src/multi-index/reader.js
+++ b/src/multi-index/reader.js
@@ -29,7 +29,7 @@ export const createReader = ({ reader, state }) =>
 
 /**
  * @template {import('../api.js').ReaderState} S
- * @template {import('../api.js').IndexItem} V
+ * @template {import('../api.js').Unit} V
  * @template {{ state: import('./api.js').MultiIndexReaderState }} View
  * @param {View} view
  * @param {import('./api.js').IndexReaderFactory<S, V>} factory
@@ -105,7 +105,7 @@ class MultiIndexReader {
   /**
    * Add an index reader implementation.
    * @template {import('../api.js').ReaderState} S
-   * @template {import('../api.js').IndexItem} V
+   * @template {import('../api.js').Unit} V
    * @param {import('./api.js').IndexReaderFactory<S, V>} factory
    */
   add (factory) {

--- a/src/universal/api.ts
+++ b/src/universal/api.ts
@@ -1,9 +1,10 @@
+import { IndexItem } from '../index-sorted/api.js'
 import { MultihashIndexItem } from '../mh-index-sorted/api.js'
 import { MultiIndexItem } from '../multi-index/api.js'
-import { ReaderState, IndexReader, IndexItem } from '../api.js'
+import { ReaderState, IndexReader } from '../api.js'
 
 export interface UniversalReaderState extends ReaderState {
-  reader?: IndexReader
+  reader?: IndexReader<ReaderState, UniversalIndexItem>
 }
 
 export type UniversalIndexItem = IndexItem | MultihashIndexItem | MultiIndexItem

--- a/src/universal/reader.js
+++ b/src/universal/reader.js
@@ -4,7 +4,7 @@ import { IndexSortedReader } from '../index-sorted/index.js'
 import { MultihashIndexSortedReader } from '../mh-index-sorted/index.js'
 import { MultiIndexReader } from '../multi-index/index.js'
 
-/** @type {Record<number, import('../multi-index/api.js').IndexReaderFactory>} */
+/** @type {Record<number, import('../multi-index/api.js').IndexReaderFactory<any, any>>} */
 const indexReaders = {
   [IndexSortedReader.codec]: IndexSortedReader,
   [MultihashIndexSortedReader.codec]: MultihashIndexSortedReader

--- a/test/cid-index-sorted.spec.js
+++ b/test/cid-index-sorted.spec.js
@@ -1,0 +1,88 @@
+/* global TransformStream */
+import test from 'ava'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import varint from 'varint'
+import { CarIndexer } from '@ipld/car/indexer'
+import { sha256, sha512 } from 'multiformats/hashes/sha2'
+import { blake2b256 } from '@multiformats/blake2/blake2b'
+import { equals } from 'multiformats/bytes'
+import { CIDIndexSortedReader, CIDIndexSortedWriter } from '../src/cid-index-sorted/index.js'
+import { collect } from './helpers/collect.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+test('creates an index', async t => {
+  const carPath = path.join(__dirname, 'fixtures', 'QmQRE4diFXfUjLfZREuzfMzWPJiQddaYBnoLjqUP1y7upn.car')
+  const carStream = fs.createReadStream(carPath)
+  const indexer = await CarIndexer.fromIterable(carStream)
+  const { readable, writable } = new TransformStream()
+  const writer = CIDIndexSortedWriter.createWriter({ writer: writable.getWriter() })
+
+  const closePromise = t.notThrowsAsync(async () => {
+    for await (const { cid, blockOffset, blockLength } of indexer) {
+      await writer.add({ cid, offset: blockOffset, length: blockLength })
+    }
+    await writer.close()
+  })
+
+  const chunks = await collect(readable)
+  t.is(varint.decode(chunks[0]), CIDIndexSortedWriter.codec)
+
+  await closePromise
+})
+
+test('reads an index', async t => {
+  const carPath = path.join(__dirname, 'fixtures', 'QmQRE4diFXfUjLfZREuzfMzWPJiQddaYBnoLjqUP1y7upn.car')
+  const carStream = fs.createReadStream(carPath)
+  const indexer = await CarIndexer.fromIterable(carStream)
+  const { readable, writable } = new TransformStream()
+  const writer = CIDIndexSortedWriter.createWriter({ writer: writable.getWriter() })
+
+  /** @type {import('multiformats').UnknownLink[]} */
+  const cids = []
+
+  const closePromise = t.notThrowsAsync(async () => {
+    for await (const { cid, blockOffset, blockLength } of indexer) {
+      cids.push(cid)
+      await writer.add({ cid, offset: blockOffset, length: blockLength })
+    }
+    await writer.close()
+  })
+
+  const reader = CIDIndexSortedReader.createReader({ reader: readable.getReader() })
+
+  const handle = await fs.promises.open(carPath)
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    const { cid, offset, length } = value
+    const i = cids.findIndex(c => c.toString() === cid.toString())
+    t.true(i >= 0, `CID ${cid} not found in: ${cids}`)
+    console.log(`${cid} @ ${offset} => ${offset + length}`)
+    cids.splice(i, 1)
+
+    // check offset/length corresponds to actual block bytes
+    const { buffer } = await handle.read({
+      buffer: new Uint8Array(length),
+      position: offset,
+      length
+    })
+    const hash = await getHasher(cid).digest(buffer)
+    t.true(equals(hash.digest, cid.multihash.digest))
+  }
+
+  await closePromise
+})
+
+/** @param {import('multiformats').UnknownLink} cid */
+const getHasher = cid => {
+  switch (cid.multihash.code) {
+    case sha256.code: return sha256
+    case sha512.code: return sha512
+    case blake2b256.code: return blake2b256
+  }
+  throw new Error(`unknown hasher: 0x${cid.multihash.code.toString(16)}`)
+}

--- a/test/index-sorted.spec.js
+++ b/test/index-sorted.spec.js
@@ -20,7 +20,7 @@ test('creates an index', async t => {
 
   const closePromise = t.notThrowsAsync(async () => {
     for await (const { cid, offset } of indexer) {
-      await writer.add(cid, offset)
+      await writer.add({ digest: cid.multihash.digest, offset })
     }
     await writer.close()
   })
@@ -38,13 +38,13 @@ test('reads an index', async t => {
   const { readable, writable } = new TransformStream()
   const writer = IndexSortedWriter.createWriter({ writer: writable.getWriter() })
 
-  /** @type {import('multiformats').CID[]} */
+  /** @type {import('multiformats').UnknownLink[]} */
   const cids = []
 
   const closePromise = t.notThrowsAsync(async () => {
     for await (const { cid, offset } of indexer) {
       cids.push(cid)
-      await writer.add(cid, offset)
+      await writer.add({ digest: cid.multihash.digest, offset })
     }
     await writer.close()
   })

--- a/test/mh-index-sorted.spec.js
+++ b/test/mh-index-sorted.spec.js
@@ -22,7 +22,7 @@ test('creates an index', async t => {
 
   const closePromise = t.notThrowsAsync(async () => {
     for await (const { cid, offset } of indexer) {
-      await writer.add(cid, offset)
+      await writer.add({ multihash: cid.multihash, offset })
     }
     await writer.close()
   })
@@ -40,13 +40,13 @@ test('reads an index', async t => {
   const { readable, writable } = new TransformStream()
   const writer = MultihashIndexSortedWriter.createWriter({ writer: writable.getWriter() })
 
-  /** @type {import('multiformats').CID[]} */
+  /** @type {import('multiformats').UnknownLink[]} */
   const cids = []
 
   const closePromise = t.notThrowsAsync(async () => {
     for await (const { cid, offset } of indexer) {
       cids.push(cid)
-      await writer.add(cid, offset)
+      await writer.add({ multihash: cid.multihash, offset })
     }
     await writer.close()
   })
@@ -56,9 +56,9 @@ test('reads an index', async t => {
   while (true) {
     const { done, value } = await reader.read()
     if (done) break
-    const { multihash, digest, offset } = value
-    const i = cids.findIndex(cid => equals(cid.multihash.digest, digest))
-    t.true(i >= 0, `CID with digest ${digest} not found`)
+    const { multihash, offset } = value
+    const i = cids.findIndex(cid => equals(cid.multihash.digest, multihash.digest))
+    t.true(i >= 0, `CID with digest ${multihash.digest} not found`)
     console.log(`${CID.createV1(raw.code, multihash)} (aka ${cids[i]}) @ ${offset}`)
     cids.splice(i, 1)
   }

--- a/test/multi-index.spec.js
+++ b/test/multi-index.spec.js
@@ -30,7 +30,7 @@ test('creates an index', async t => {
       const carStream = fs.createReadStream(carPath)
       const indexer = await CarIndexer.fromIterable(carStream)
       for await (const { cid, offset } of indexer) {
-        await indexWriter.add(cid, offset)
+        await indexWriter.add({ multihash: cid.multihash, offset })
       }
       await indexWriter.close()
     })
@@ -61,7 +61,7 @@ test('reads an index', async t => {
       const indexer = await CarIndexer.fromIterable(carStream)
       for await (const { cid, offset } of indexer) {
         blocks.push({ block: cid, origin: carCID })
-        await indexWriter.add(cid, offset)
+        await indexWriter.add({ multihash: cid.multihash, offset })
       }
       await indexWriter.close()
     })
@@ -74,9 +74,9 @@ test('reads an index', async t => {
     const { done, value } = await reader.read()
     if (done) break
     // @ts-expect-error
-    const { origin, multihash, digest, offset } = value
-    const i = blocks.findIndex(b => equals(b.block.multihash.digest, digest) && equals(b.origin.multihash.digest, origin.multihash.digest))
-    t.true(i >= 0, `CID with digest ${digest} not found`)
+    const { origin, multihash, offset } = value
+    const i = blocks.findIndex(b => equals(b.block.multihash.digest, multihash.digest) && equals(b.origin.multihash.digest, origin.multihash.digest))
+    t.true(i >= 0, `CID with digest ${multihash.digest} not found`)
     console.log(`${CID.createV1(raw.code, multihash)} (aka ${blocks[i].block}) @ ${offset}`)
     blocks.splice(i, 1)
   }


### PR DESCRIPTION
This PR adds a `CIDIndexSorted` index.

This is the alternative mentioned in https://github.com/web3-storage/RFC/pull/9

The format is:

```
varint codec
  uint8 number of CID versions
     (for each)
     uint8 CID version
     uint32 number of IPLD codecs
         (for each)
         uint64 IPLD codec
         uint32 number of multihash codecs
             (for each)
             uint64 multihash codec
             uint32 number of "width" groups
                 (for each)
                 uint32 group "width"
                 uint64 group length
                     (for each)
                     digest
                     uint64 offset
                     uint64 length
```

The format is _very_ similar to `MultihashIndexSorted`. The difference is that it captures CID version, IPLD codec, offset from block bytes (NOT block header) AND length (the number of bytes the block is made of).

CID versions MUST be stored ASC.

Usage:

```js
import fs from 'fs'
import { Readable } from 'stream'
import { CarIndexer } from '@ipld/car/indexer'
import { CIDIndexSortedWriter } from 'cardex/cid-index-sorted'

const carStream = fs.createReadStream('my.car')
const indexer = await CarIndexer.fromIterable(carStream)

const { readable, writable } = new TransformStream()
const writer = CIDIndexSortedWriter.createWriter({ writer: writable.getWriter() })

readable.pipeTo(Readable.toWeb(fs.createWriteStream('my.car.idx')))

for await (const { cid, blockOffset, blockLength } of indexer) {
  await writer.add({ cid, offset: blockOffset, length: blockLength })
}
await writer.close()
```

